### PR TITLE
Prevent unauthorized users from modifying an event's shifts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,31 +9,21 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 
 gem 'coffee-rails', '~> 4.1.0'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
 
-# Use jquery as the JavaScript library
 gem 'jquery-rails'
-# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
+
 gem 'turbolinks'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+
 gem 'jbuilder', '~> 2.0'
-# bundle exec rake doc:rails generates the API under doc/api.
+
 gem 'sdoc', '~> 0.4.0', group: :doc
 
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use Unicorn as the app server
-# gem 'unicorn'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
-
-# Use bcrypt to securely hash passwords
 gem 'bcrypt', '~> 3.1.7'
 gem 'mailboxer'
+
+
 gem 'devise', '~> 4.0.0.rc2'
+gem 'cancancan', '~> 1.8'
 
 gem 'rerun'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
     byebug (8.2.2)
+    cancancan (1.13.1)
     cane (2.6.2)
       parallel
     capybara (2.6.2)
@@ -354,6 +355,7 @@ DEPENDENCIES
   autotest-rails
   bcrypt (~> 3.1.7)
   byebug
+  cancancan (~> 1.8)
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)
   cucumber-rails

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,13 @@
 class EventsController < ApplicationController
 
+  before_action :parse_user
+
+  def parse_user
+    @user = current_user
+  end
+
   def event_params
-    params.require(:event).permit(:user_id, :location, :event_name, :event_date, :candidate, :description)
+    params.require(:event).permit(:location, :event_name, :event_date, :candidate, :description)
   end
 
   def show
@@ -13,7 +19,7 @@ class EventsController < ApplicationController
   end
 
   def create
-    @event = Event.create event_params
+    @event = Event.create event_params.merge(user: @user)
     if @event.invalid?
       flash[:error] = @event.errors.full_messages.first
       redirect_to '/events/new'

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -13,17 +13,18 @@ class ShiftsController < ApplicationController
     @shift = Shift.find params[:id]
   end
 
-  def new
-  end
-
   def create
-    @shift = Shift.create shift_params.merge(event: @event)
-    if @shift.invalid?
-      flash[:error] = shift.errors.full_messages.first
-      redirect_to new_event_shift_path
+    if can? :create_shift, @event
+      @shift = Shift.create shift_params.merge(event: @event)
+      if @shift.invalid?
+        flash[:error] = shift.errors.full_messages.first
+        redirect_to new_event_shift_path
+      else
+        flash[:notice] = "#{@shift.role} shift was successfully created."
+        redirect_to event_shift_path @event, @shift
+      end
     else
-      flash[:notice] = "#{@shift.role} shift was successfully created."
-      redirect_to event_shift_path @event, @shift
+      render file: "public/422.html", status: :unauthorized
     end
   end
 
@@ -33,17 +34,25 @@ class ShiftsController < ApplicationController
 
   def update
     @shift = Shift.find params[:id]
-    @shift.update_attributes!(shift_params)
-    flash[:notice] = "#{@shift.role} shift was successfully updated."
-    redirect_to event_shift_path @event, @shift
+    if can? :update, @shift
+      @shift.update_attributes shift_params
+      flash[:notice] = "#{@shift.role} shift was successfully updated."
+      redirect_to event_shift_path @event, @shift
+    else
+      render file: "public/422.html", status: :unauthorized
+    end
   end
 
   def destroy
     @shift = Shift.find params[:id]
 
-    @shift.destroy
-    flash[:notice] = " '#{@shift.role}' shift deleted."
-    redirect_to event_path @event
+    if can? :destroy, @shift
+      @shift.destroy
+      flash[:notice] = " '#{@shift.role}' shift deleted."
+      redirect_to event_path @event
+    else
+      render file: 'public/422.html', status: :unauthorized
+    end
   end
   
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,7 @@ class UsersController < ActionController::Base
   def leave_shift
     @shift = Shift.find params[:id]
     @commitment = VolunteerCommitment.find_by user: @user, shift: @shift
+
     unless @commitment.nil?
       flash[:notice] = 'You have left the shift'
       @commitment.destroy

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,39 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    #
+    #   user ||= User.new # guest user (not logged in)
+    #   if user.admin?
+    #     can :manage, :all
+    #   else
+    #     can :read, :all
+    #   end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+    user ||= User.new
+
+    can [:create, :read], Event
+    can [:update, :destroy, :create_shift], Event, user: {id: user.id}
+
+    can :read, Shift
+    can [:create, :update, :destroy], Shift, user: {id: user.id}
+  end
+end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -2,6 +2,7 @@ class Shift < ActiveRecord::Base
   belongs_to :event
   has_many :volunteer_commitments
   has_many :users, :through => :volunteer_commitments
+  has_one :user, :through => :event
 
   def formatted_start_time
     return self.start_time.strftime '%H:%M %p'

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -22,7 +22,9 @@
     <%= s.formatted_start_time %> to <%= s.formatted_end_time %>, <%= link_to s.role, event_shift_path(@event, s) %></br>
   <% end %>
 
-<%= link_to 'Add Shift', new_event_shift_path(@event) %><br><br>
+<% if can? :create_shift, @event%>
+  <%= link_to 'Add Shift', new_event_shift_path(@event) %><br><br>
+<% end %>
 
 <%= link_to 'Edit', edit_event_path(@event) %><br>
 <%= button_to 'Delete', event_path(@event), :method => :delete%><br>

--- a/app/views/shifts/show.html.erb
+++ b/app/views/shifts/show.html.erb
@@ -18,11 +18,20 @@ Limit: <%= @shift.limit %>
 <% end %>
 
 
-<% if current_user.signed_up_for @shift %>
-  <%= link_to 'Leave', "/user/leave_shift/#{@shift.id}" %> <br>
-<% elsif @shift.volunteer_commitments.length < @shift.limit %>
-  <%= link_to 'Join', "/user/join_shift/#{@shift.id}" %> <br>
+<% if not current_user.nil? %>
+    <% if current_user.signed_up_for @shift %>
+      <%= link_to 'Leave', "/user/leave_shift/#{@shift.id}" %> <br>
+    <% elsif @shift.volunteer_commitments.length < @shift.limit %>
+      <%= link_to 'Join', "/user/join_shift/#{@shift.id}" %> <br>
+    <% end %>
 <% end %>
-<%= link_to 'Edit', edit_event_shift_path(@event, @shift) %> <br>
-<%= button_to 'Add Shift', new_event_shift_path(@event) %> <br>
-<%= button_to 'Delete', event_shift_path(@event, @shift), :method => :delete %> <br>
+
+<% if can? :update, @shift %>
+    <%= link_to 'Edit', edit_event_shift_path(@event, @shift) %> <br>
+<%end%>
+<% if can? :create, @shift %>
+    <%= button_to 'Add Shift', new_event_shift_path(@event) %> <br>
+<% end %>
+<% if can? :destroy, @shift %>
+    <%= button_to 'Delete', event_shift_path(@event, @shift), :method => :delete %> <br>
+<% end %>

--- a/event.html.erb
+++ b/event.html.erb
@@ -1,9 +1,0 @@
-<div id = flash>
- <% if flash[:error] %>
-  <p><%= flash[:error] %></p></br>
- <% end %>
- <% if flash[:notice] %>
-  <p><%= flash[:notice] %></p></br>
- <% end %>
-</div>
-

--- a/features/create_shift.feature
+++ b/features/create_shift.feature
@@ -109,10 +109,7 @@ Feature: User can Create, edit and delete shifts
     When I fill in "Description" with "long description text"
     Then I should see enough space on the multiline textbox for the event description
 
-
-
   Scenario: Attempt to modify a shift when logged out
-    Given PENDING
     Given I am on the homepage
     Then I should see "Go Batman"
     When I follow "Logout"
@@ -124,7 +121,6 @@ Feature: User can Create, edit and delete shifts
     And I should not see "Delete"
 
   Scenario: Attempt to modify a shift when logged in as user that did not create the event
-    Given PENDING
     Given I follow "Logout"
     And I log in with username "jane_doe" and password "jane_doe_password"
     Then I should be on the homepage
@@ -132,6 +128,18 @@ Feature: User can Create, edit and delete shifts
     And I follow "Tabling"
     Then I should not see "Edit"
     And I should not see "Delete"
+    And I should not see "Leave"
+    And I should see "Join"
+
+  Scenario: Attempt to modify a shift when logged out
+    Given I follow "Logout"
+    Then I should be on the homepage
+    When I follow "Go Batman"
+    And I follow "Tabling"
+    Then I should not see "Edit"
+    And I should not see "Delete"
+    And I should not see "Leave"
+    And I should not see "Join"
 
   Scenario: Attempt to delete a shift
     Given I am on the page for the "Tabling" shift for the "Go Batman" event

--- a/spec/controllers/shifts_controller_spec.rb
+++ b/spec/controllers/shifts_controller_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+
+describe ShiftsController do
+
+  before :each do
+    @user = FactoryGirl.create :user
+    @event = FactoryGirl.create :event, user: @user
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+  end
+
+  def current_user
+    subject.current_user
+  end
+
+  describe 'POST create' do
+    it 'should not allow a shift to be created when no user is logged in' do
+      @shift = {start_time: '10:00 PM', end_time: '10:10 PM', role: 'Tabling'}
+      post :create, event_id: @event.id, shift: @shift
+
+      @event.shifts.length.should == 0
+    end
+
+    it 'should not allow a shift to be created when a user other than the event creator is not logged in' do
+      @new_user = FactoryGirl.create :user
+      @shift = {start_time: '10:00 PM', end_time: '10:10 PM', role: 'Tabling'}
+
+      sign_in @new_user
+      post :create, event_id: @event.id, shift: @shift
+
+      @event.shifts.length.should == 0
+    end
+
+    it 'should allow a shift to be created when the event creator is logged in' do
+      sign_in @user
+      @shift = {start_time: '10:00 PM', end_time: '10:10 PM', role: 'Tabling'}
+      post :create, event_id: @event.id, shift: @shift
+
+      @event.shifts.length.should == 1
+    end
+  end
+
+  describe 'PUT update' do
+    it 'should not allow a shift to be updated when no user is logged in' do
+      @shift = FactoryGirl.create :shift, event: @event
+      put :update, event_id: @event.id, id: @shift.id, shift: {role: 'Updated Tabling'}
+
+      shift = Shift.find @shift.id
+      shift.role.should_not == 'Updated Tabling'
+      shift.role.should == @shift.role
+    end
+
+    it 'should not allow a shift to be updated when a user other than the event creator is logged in' do
+      @new_user = FactoryGirl.create :user
+
+      sign_in @new_user
+      @shift = FactoryGirl.create :shift, event: @event
+      put :update, event_id: @event.id, id: @shift.id, shift: {role: 'Updated Tabling'}
+
+      shift = Shift.find @shift.id
+      shift.role.should_not == 'Updated Tabling'
+      shift.role.should == @shift.role
+    end
+
+    it 'should allow a shift to be updated when the event creator is logged in' do
+      sign_in @user
+      @shift = FactoryGirl.create :shift, event: @event
+      put :update, event_id: @event.id, id: @shift.id, shift: {role: 'Updated Tabling'}
+
+      shift = Shift.find_by @shift.id
+      shift.role.should == 'Updated Tabling'
+    end
+  end
+
+  describe 'DELETE destory' do
+    it 'should not allow a shift to be destroyed when no user is logged in' do
+      @shift = FactoryGirl.create :shift, event: @event
+      delete :destroy, event_id: @event.id, id: @shift.id
+
+      shift = Shift.find_by id: @shift.id
+      shift.nil?.should == false
+    end
+
+    it 'should not allow a shift to be destroyed whena user other than the event creator is logged in' do
+      @new_user = FactoryGirl.create :user
+
+      sign_in @new_user
+      @shift = FactoryGirl.create :shift, event: @event
+      delete :destroy, event_id: @event.id, id: @shift.id
+
+      shift = Shift.find_by id: @shift.id
+      shift.nil?.should == false
+    end
+
+    it 'should allow a shift to be destroyed whena user other than the event creator is logged in' do
+      sign_in @user
+      @shift = FactoryGirl.create :shift, event: @event
+      delete :destroy, event_id: @event.id, id: @shift.id
+
+      shift = Shift.find_by id: @shift.id
+      shift.nil?.should == true
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,15 @@
 FactoryGirl.define do
+  sequence :username do |n|
+    "test#{n}user"
+  end
+
+  sequence :email do |n|
+    "test#{n}@example.com"
+  end
+
   factory :user do
-    email 'user@email.com'
-    username 'username'
+    email {generate :email}
+    username {generate :username}
     password 'password'
     password_confirmation 'password'
     city 'Berkeley'
@@ -11,6 +19,12 @@ FactoryGirl.define do
     event_name 'Test Event'
     event_date '10/04/2018'
     location 'Berkeley'
-    candidate 'Batman'
+    candidate 'Test Candidate'
+  end
+
+  factory :shift do
+    start_time '10:00 PM'
+    end_time '10:10 PM'
+    role 'Tabling'
   end
 end


### PR DESCRIPTION
Update the shift controller so that it only allows the event creator to create, update and delete a shift. Adds a dependency on cancancan in order to verify permissions. Create, Update and Delete options are no longer visible if the user is not authorized to execute those actions.