### PR TITLE
Remove notifications for deleted events and shifts

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,6 +10,9 @@ class Event < ActiveRecord::Base
   validates :event_date, presence: true
   validates :location, presence: true
   validates :candidate, presence: true
+  after_destroy do
+    UserActivity.destroy_all(event_id: self.id)
+  end
 
   # Orders shifts by start time
   def ordered_shifts

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -10,6 +10,9 @@ class Shift < ActiveRecord::Base
   validates :end_time, presence: true
   validates :role, presence: true
   validates :has_limit, inclusion: {in: [true, false]}
+  after_destroy do
+    UserActivity.destroy_all(shift_id: self.id)
+  end
 
   def format time
     time.strftime '%I:%M %p'


### PR DESCRIPTION
When events and shifts are deleted, remove notifications for those events or shifts.