### PR TITLE
No reminder notifiations for same day events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -103,7 +103,9 @@ class EventsController < ApplicationController
   
   def event_create_activity event
     EventCreateMailer.notify_creator(@event).deliver_now
-    EventNotificationJob.set(wait_until: event.event_date.to_time.advance(:days => -1)).perform_later event
     EventCreateActivity.create :owner_id => event.user.id, :user_id => nil, :shift_id => nil, :event_id => event.id
+    if event.event_date.future?
+      EventNotificationJob.set(wait_until: event.event_date.to_time.advance(:days => -1)).perform_later event
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,7 +44,9 @@ class UsersController < ApplicationController
     creator_id = shift.user.id
     JoinActivity.create :owner_id => creator_id, :user_id => user.id, :shift_id => shift.id, :event_id => shift.event.id
     UserJoinActivity.create :owner_id => user.id, :user_id => nil, :shift_id => shift.id, :event_id => shift.event.id
-    ShiftNotificationJob.set(wait_until: shift.event.event_date.to_time.advance(:days => -1)).perform_later shift, user
+    if shift.event.event_date.future?
+      ShiftNotificationJob.set(wait_until: shift.event.event_date.to_time.advance(:days => -1)).perform_later shift, user
+    end
     if shift.has_limit and shift.volunteer_commitments.length == shift.limit
       ShiftFullActivity.create :owner_id => creator_id, :user_id => nil, :shift_id => shift.id, :event_id => shift.event.id
     end

--- a/features/event_shift_notifications.feature
+++ b/features/event_shift_notifications.feature
@@ -34,7 +34,7 @@ Feature: Users will receive timely notifications for events and shifts
     And I fill in "Description" with "Honor Harvey Dent"
     And I press "Create Event"
     When I am on the user activity page
-    Then I should see "Your 'Harvey Dent Day' event is tomorrow."
+    Then I should not see "Your 'Harvey Dent Day' event is tomorrow."
     
   Scenario: Receive timely event notification for copied events
     Given I am on the page for the "Go Batman" event


### PR DESCRIPTION
Reminder notification jobs will only be generated if the event.event_date is after today's date.