### PR TITLE
Fix reminder notification after event date changes

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,7 +45,7 @@ class UsersController < ApplicationController
     JoinActivity.create :owner_id => creator_id, :user_id => user.id, :shift_id => shift.id, :event_id => shift.event.id
     UserJoinActivity.create :owner_id => user.id, :user_id => nil, :shift_id => shift.id, :event_id => shift.event.id
     if shift.event.event_date.future?
-      ShiftNotificationJob.set(wait_until: shift.event.event_date.to_time.advance(:days => -1)).perform_later shift, user
+      ShiftNotificationJob.set(wait_until: shift.event.event_date.to_time - 1.day).perform_later user, shift
     end
     if shift.has_limit and shift.volunteer_commitments.length == shift.limit
       ShiftFullActivity.create :owner_id => creator_id, :user_id => nil, :shift_id => shift.id, :event_id => shift.event.id

--- a/app/jobs/event_notification_job.rb
+++ b/app/jobs/event_notification_job.rb
@@ -2,8 +2,10 @@ class EventNotificationJob < ActiveJob::Base
   queue_as :default
 
   def perform(event)
-    creator_id = event.user.id
-    EventReminderMailer.notify_creator(event).deliver_now
-    EventTimeActivity.create :owner_id => creator_id, :user_id => nil, :shift_id => nil, :event_id => event.id
+    if Event.exists?(event.id) && Date.today == event.event_date.prev_day && !EventTimeActivity.exists?(:event_id => event.id)
+      creator_id = event.user.id
+      EventReminderMailer.notify_creator(event).deliver_now
+      EventTimeActivity.create :owner_id => creator_id, :user_id => nil, :shift_id => nil, :event_id => event.id
+    end
   end
 end

--- a/app/jobs/shift_notification_job.rb
+++ b/app/jobs/shift_notification_job.rb
@@ -1,7 +1,9 @@
 class ShiftNotificationJob < ActiveJob::Base
   queue_as :default
 
-  def perform(shift, user)
-    ShiftTimeActivity.create :owner_id => user.id, :user_id => user.id, :shift_id => shift.id, :event_id => shift.event.id
+  def perform(user, shift)
+    if (VolunteerCommitment.exists?(:user_id => user.id, :shift_id => shift.id) && Date.today == shift.event.event_date.prev_day && !ShiftTimeActivity.exists?(:user_id => user.id, :shift_id => shift.id))
+      ShiftTimeActivity.create :owner_id => user.id, :user_id => user.id, :shift_id => shift.id, :event_id => shift.event.id
+    end
   end
 end

--- a/app/models/user_activities/event_time_activity.rb
+++ b/app/models/user_activities/event_time_activity.rb
@@ -1,13 +1,5 @@
 class EventTimeActivity < UserActivity
 
-    validate :event_exists
-    
-    def event_exists
-        if not Event.exists? event.id
-            errors.add :event, "no longer exists" 
-        end
-    end
-    
     def href
         Rails.application.routes.url_helpers.event_path event
     end

--- a/app/models/user_activities/shift_time_activity.rb
+++ b/app/models/user_activities/shift_time_activity.rb
@@ -1,11 +1,4 @@
 class ShiftTimeActivity < UserActivity
-    validate :commitment_exists
-    
-    def commitment_exists
-        if not VolunteerCommitment.exists? :user_id => owner_id, :shift_id => shift_id
-            errors.add :commitment, "no longer exists" 
-        end
-    end
     
     def href
         Rails.application.routes.url_helpers.event_shift_path event, shift

--- a/features/event_shift_notifications.feature
+++ b/features/event_shift_notifications.feature
@@ -10,10 +10,12 @@ Feature: Users will receive timely notifications for events and shifts
       | john_doe@uprise.com | john_doe | hellboy_new  |
     And I am on the homepage
     And I log in with username "john_doe" and password "hellboy_new"
+    And the following events will be held tomorrow:
+      | User     | Name      | Candidate   | Location |
+      | john_doe | Go Batman | Batman      | Gotham   |
     And the following events exist:
-      | User     | Event Date | Name      | Candidate   | Location |
-      | john_doe | 04/8/2100  | Go Batman | Batman      | Gotham   |
-      | john_doe | 05/8/2100  | Go Harvey | Harvey Dent | Gotham   |
+      | User     | Name      | Event Date | Candidate   | Location |
+      | john_doe | Go Harvey | 03/03/2100 |Harvey Dent | Gotham   |
     And the following shifts exist:
       | Event     | Role     | Has Limit | Limit | Start Time | End Time | Description   |
       | Go Batman | Tabling  | true      | 4     | 11:00 am   | 11:30 am | Sit all day   |
@@ -25,7 +27,7 @@ Feature: Users will receive timely notifications for events and shifts
     Given I am on the user activity page
     Then I should see "Your 'Tabling' shift for the 'Go Batman' event is tomorrow."
 
-  Scenario: Receive shift notification 24 hours before an event
+  Scenario: Don't receive shift notification for events on the same day
     Given I am on the home page
     When I follow "Create"
     When I fill in "Event Name" with "Harvey Dent Day"
@@ -35,6 +37,12 @@ Feature: Users will receive timely notifications for events and shifts
     And I press "Create Event"
     When I am on the user activity page
     Then I should not see "Your 'Harvey Dent Day' event is tomorrow."
+    
+  Scenario: Don't receive notifications for events created more than a day in advance
+    Given I am on the page for the "Go Harvey" event
+    When I follow "Copy Event"
+    And I am on the user activity page
+    Then I should not see "Your 'Go Harvey(Copy)' event is tomorrow."
     
   Scenario: Receive timely event notification for copied events
     Given I am on the page for the "Go Batman" event

--- a/features/step_definitions/custom_steps.rb
+++ b/features/step_definitions/custom_steps.rb
@@ -17,6 +17,14 @@ Given (/^the following events exist:$/) do |table|
   end
 end
 
+Given (/^the following events will be held tomorrow:$/) do |table|
+  table.hashes.each do |event|
+    Event.create user: User.find_by(username: event['User']), event_name: event['Name'],
+                                    candidate: event['Candidate'], event_date: Date.tomorrow,
+                                    location: event['Location'], start_time: '10:00 AM', end_time: '11:00 AM'
+  end
+end
+
 Given (/^the following shifts exist:$/) do |table|
   table.hashes.each do |shift|
     Shift.create event: Event.find_by(event_name: shift['Event']), role: shift['Role'],


### PR DESCRIPTION
After event date is changed, generate new reminder jobs.

When jobs are run, check three conditions before creating reminder notification:
-Does event/volunteer commitment still exist?
-Is it currently one day before event date?
-Does no identical notification already exist? (Avoid duplicate notifications if event changed back to old date)

Added custom step to create events for tomorrow.