### PR TITLE
Notify user about a shift with matching skills

### DIFF
--- a/app/mailers/matching_shift_mailer.rb
+++ b/app/mailers/matching_shift_mailer.rb
@@ -1,0 +1,10 @@
+class MatchingShiftMailer < NotificationMailer
+
+  def notify_user user, shift
+    super
+    @event = shift.event
+    @subject = 'Your skills are needed!'
+
+    mail to: user.email, subject: @subject, template_name: :matching_shift_mailer
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,7 +11,9 @@ class Event < ActiveRecord::Base
   validates :location, presence: true
   validates :candidate, presence: true
 
-  after_destroy do
+  after_destroy :cleanup
+
+  def cleanup
     UserActivity.destroy_all(event_id: self.id)
   end
 

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -1,8 +1,8 @@
 class Shift < ActiveRecord::Base
   belongs_to :event
   has_many :volunteer_commitments
-  has_many :ShiftSkills
-  has_many :skills, through: :ShiftSkills
+  has_many :shift_skills
+  has_many :skills, through: :shift_skills
   has_many :users, through: :volunteer_commitments
   has_one :user, through: :event
 
@@ -10,9 +10,13 @@ class Shift < ActiveRecord::Base
   validates :end_time, presence: true
   validates :role, presence: true
   validates :has_limit, inclusion: {in: [true, false]}
-  after_destroy do
+
+  after_destroy :cleanup
+
+  def cleanup
     UserActivity.destroy_all(shift_id: self.id)
   end
+
 
   def format time
     time.strftime '%I:%M %p'

--- a/app/models/user_activities/matching_shift_activity.rb
+++ b/app/models/user_activities/matching_shift_activity.rb
@@ -1,0 +1,10 @@
+class MatchingShiftActivity < UserActivity
+
+  def href
+    event_shift_path event, shift
+  end
+
+  def representation
+    "Your skills are needed for the #{self.shift.role} shift of the #{self.event.event_name} event"
+  end
+end

--- a/app/models/user_activities/user_activity.rb
+++ b/app/models/user_activities/user_activity.rb
@@ -2,13 +2,15 @@ class UserActivity < ActiveRecord::Base
     belongs_to :user
     belongs_to :shift
     belongs_to :event
+
+    include Rails.application.routes.url_helpers
     
     def href
-        raise "You must instantiate subclass of UserActivity"
+        raise 'You must instantiate subclass of UserActivity'
     end
     
     def representation
-        raise "You must instantiate subclass of UserActivity"
+        raise 'You must instantiate subclass of UserActivity'
     end
         
     

--- a/app/views/notification_mailer/matching_shift_mailer.html.erb
+++ b/app/views/notification_mailer/matching_shift_mailer.html.erb
@@ -1,0 +1,3 @@
+<p>Someone needs your skills for the following shift. Can you help out?</p>
+<%= render 'shared/shift_information' %>
+<%= render 'shared/event_information' %>

--- a/features/create_shift.feature
+++ b/features/create_shift.feature
@@ -185,6 +185,23 @@ Feature: User can Create, edit and delete shifts
     And I should not see "Walking"
     And I should not see "Spanish"
 
+  Scenario: User is notified about shift with matching skills
+    Given the following user skills exist:
+    | User     | Skill   |
+    | john_doe | Walking |
+    And I am on the page for the "Go Batman" event
+    When I follow "Add Shift"
+    Then I should be on the new shift page for the "Go Batman" event
+    When I select "1:00 PM" as the shift "Start Time"
+    And I select "3:00 PM" as the shift "End Time"
+    And I fill in "Shift Role" with "Set Up"
+    And I check "Shift Has Limit"
+    And I fill in "Shift Limit" with "5"
+    And I select the following skills: "Walking, Spanish"
+    And I press "Add Shift"
+    And I follow "Notifications"
+    Then I should see "Your skills are needed for the Set Up shift of the Go Batman event"
+
   Scenario: If start time after end time, valid input should be preserved
     Given PENDING
     Given I am on the page for the "Go Batman" event

--- a/features/step_definitions/custom_steps.rb
+++ b/features/step_definitions/custom_steps.rb
@@ -49,6 +49,15 @@ Given(/^the following shift skills exist:$/) do |table|
   end
 end
 
+Given(/^the following user skills exist:$/) do |table|
+  table.hashes.each do |user_skill|
+    user = User.find_by_username user_skill['User']
+    skill = Skill.find_by_description user_skill['Skill']
+
+    UserSkill.create user: user, skill: skill
+  end
+end
+
 Given(/^the following volunteer commitments exist:$/) do |table|
   table.hashes.each do |commitment|
     user = User.find_by username: commitment['User']


### PR DESCRIPTION
- Send a notification via email about the creation of a shift with skills that match the user's profile
- Generate an in-app notification about the creation of a shift with skills that match the user's profile